### PR TITLE
修复导出 Decompile 阶段进度弹窗闪烁

### DIFF
--- a/INP.py
+++ b/INP.py
@@ -441,7 +441,7 @@ class _FuncExportJob(object):
     # ------------------------------------------------------------------
 
     def _build_status_msg(self, stage_hint=None):
-        """构建包含详细进度信息的等待框文本。"""
+        """构建包含详细进度信息的等待框文本（固定 5 行宽度，避免弹窗随内容 resize）。"""
         total = len(self.remaining_funcs)
         elapsed = time.time() - self._job_start_time
         elapsed_str = "{:02d}:{:02d}".format(int(elapsed) // 60, int(elapsed) % 60)
@@ -454,47 +454,57 @@ class _FuncExportJob(object):
         else:
             eta_str = "--:--"
 
-        lines = []
-        # 第一行：阶段 + 总进度
-        lines.append("[Stage 6/6] Decompile: {}/{} ({:.0f}%)".format(
-            self.idx, total, (self.idx / total * 100) if total else 0))
+        pct = (self.idx / total * 100) if total else 0
+        lines = [
+            "[Stage 6/6] Decompile: {:6d}/{:6d} ({:3.0f}%)".format(self.idx, total, pct),
+            "OK={:5d} | Fallback={:5d} | Failed={:5d} | Skip={:5d}".format(
+                self.exported_funcs, len(self.fallback_funcs),
+                len(self.failed_funcs), len(self.skipped_funcs)),
+        ]
 
-        # 第二行：统计
-        lines.append("OK={} | Fallback={} | Failed={} | Skip={}".format(
-            self.exported_funcs, len(self.fallback_funcs),
-            len(self.failed_funcs), len(self.skipped_funcs)))
-
-        # 第三行：当前函数
+        # 第三行：当前函数（无当前时也占位，保持行数不变）
         if self._current_func_name:
             func_time = time.time() - self._current_func_start_time
             func_label = self._current_func_name
             if len(func_label) > 40:
                 func_label = func_label[:37] + "..."
             status_icon = stage_hint or "decompiling"
-            lines.append(">> {} @ {} ({:.1f}s)".format(
-                status_icon, func_label, func_time))
+            current_body = "{} @ {} ({:.1f}s)".format(status_icon, func_label, func_time)
+        else:
+            current_body = "-"
+        lines.append(">> " + self._fit_wait_box_field(current_body, 56))
 
-        # 第四行：上一个函数结果
+        # 第四行：上一个函数结果（无结果时也占位）
         if self._last_func_name:
             last_label = self._last_func_name
-            if len(last_label) > 35:
-                last_label = last_label[:32] + "..."
+            if len(last_label) > 32:
+                last_label = last_label[:29] + "..."
             if self._last_func_status == "ok":
-                lines.append("<< OK: {} ({:.1f}s)".format(last_label, self._last_func_time))
+                last_body = "OK: {} ({:.1f}s)".format(last_label, self._last_func_time)
             elif self._last_func_status == "fallback":
-                lines.append("<< FALLBACK: {} ({:.1f}s)".format(last_label, self._last_func_time))
+                last_body = "FALLBACK: {} ({:.1f}s)".format(last_label, self._last_func_time)
             elif self._last_func_status == "failed":
                 err = self._last_error_msg or "unknown"
                 if len(err) > 40:
                     err = err[:37] + "..."
-                lines.append("<< FAILED: {} - {}".format(last_label, err))
+                last_body = "FAILED: {} - {}".format(last_label, err)
             elif self._last_func_status == "skipped":
-                lines.append("<< SKIP: {}".format(last_label))
+                last_body = "SKIP: {}".format(last_label)
+            else:
+                last_body = "-"
+        else:
+            last_body = "-"
+        lines.append("<< " + self._fit_wait_box_field(last_body, 56))
 
-        # 第五行：时间
         lines.append("Elapsed: {} | ETA: {} | Cancel to abort".format(elapsed_str, eta_str))
-
         return "\n".join(lines)
+
+    @staticmethod
+    def _fit_wait_box_field(text, width):
+        """截断或右侧空格补齐到固定宽度，避免 wait box 随文本长度 resize。"""
+        if len(text) > width:
+            return text[:width - 3] + "..."
+        return text.ljust(width)
 
     def _update_wait_box(self, msg=None):
         """更新等待框显示。

--- a/INP.py
+++ b/INP.py
@@ -1688,8 +1688,8 @@ class _ExportPipeline(object):
         """由 IDA 定时器调用。处理当前阶段的一个工作单元。"""
         self._tick_start = time.time()
 
-        # 检查用户取消
-        if self._wait_box_active and ida_kernwin.user_cancelled():
+        # 检查用户取消（Decompile 阶段由 job 处理 cancel，避免 pipeline 抢先 _finish）
+        if not self._job_owns_wait_box() and self._wait_box_active and ida_kernwin.user_cancelled():
             self._finish(cancelled=True)
             return -1
 
@@ -1698,7 +1698,8 @@ class _ExportPipeline(object):
             self._finish(cancelled=False)
             return -1
 
-        self._update_wait_box()
+        if not self._job_owns_wait_box():
+            self._update_wait_box()
 
         # 动态构建 handlers 列表
         handlers = []
@@ -1779,6 +1780,14 @@ class _ExportPipeline(object):
     # ------------------------------------------------------------------
     # 等待框管理
     # ------------------------------------------------------------------
+
+    def _job_owns_wait_box(self):
+        """Decompile 阶段 job 已创建后，由 job 单独更新 wait box。"""
+        if self._phase >= len(self._phase_names):
+            return False
+        if self._phase_names[self._phase] != "Decompile":
+            return False
+        return self._phase_initialized and self._job is not None
 
     def _update_wait_box(self, extra=""):
         if self._phase >= self._total_phases:
@@ -2120,9 +2129,11 @@ class _ExportPipeline(object):
                 force_reexport=self.force_reexport,
             )
             self._job._start_time = self._start_time
+            # 继承 pipeline 已显示的 wait box，避免 job 再次 show_wait_box 重建对话框
+            self._job._wait_box_active = self._wait_box_active
+            self._wait_box_active = False
             _active_export_job = self._job
             self._phase_initialized = True
-            self._wait_box_active = False  # job 会管理自己的等待框
             return False  # 阶段未完成，pipeline timer 继续调用
 
         # 后续调用：委托给 job.tick()


### PR DESCRIPTION
在处理较大文件时，发现 Decompile 阶段中弹窗交替刷新，有如下两点

1. pipeline 与 job 同时更新 wait box，单行 Stage 进度与多行详情来回切换导致尺寸跳动。现由 job 独占更新，并正确移交 wait box / Cancel 所有权，避免 pipeline 抢先 _finish 造成 _active_export_job 泄漏。
2. 进度文本行数、函数名长度不固定，每次 replace_wait_box 都会改变弹窗大小。现改为固定 5 行布局与定宽字段，无内容时用占位符补齐。

修复前：

https://github.com/user-attachments/assets/cb06cba1-6d6d-47e5-8fb0-b20c5291a8d8

修复后：

https://github.com/user-attachments/assets/a209cd32-6f42-4294-8acf-328f7ed687c3